### PR TITLE
Rendering

### DIFF
--- a/ges/ges-layer.c
+++ b/ges/ges-layer.c
@@ -348,6 +348,8 @@ ges_layer_set_priority (GESLayer * layer, guint priority)
 
     ges_layer_resync_priorities (layer);
   }
+
+  g_object_notify (G_OBJECT (layer), "priority");
 }
 
 /**

--- a/ges/ges-timeline-pipeline.c
+++ b/ges/ges-timeline-pipeline.c
@@ -376,13 +376,16 @@ ges_timeline_pipeline_update_caps (GESTimelinePipeline * self)
           GstCaps *ocaps, *rcaps;
 
           GST_DEBUG ("Smart Render mode, setting input caps");
-          ocaps = gst_encoding_profile_get_input_caps (prof);
+          ocaps =
+              gst_caps_make_writable (gst_encoding_profile_get_input_caps
+              (prof));
           if (track->type == GES_TRACK_TYPE_AUDIO)
             rcaps = gst_caps_new_empty_simple ("audio/x-raw");
           else
             rcaps = gst_caps_new_empty_simple ("video/x-raw");
           gst_caps_append (ocaps, rcaps);
           ges_track_set_caps (track, ocaps);
+          gst_caps_unref (ocaps);
         } else {
           GstCaps *caps = NULL;
 

--- a/ges/ges-uri-asset.c
+++ b/ges/ges-uri-asset.c
@@ -425,14 +425,14 @@ ges_uri_clip_asset_new (const gchar * uri, GCancellable * cancellable,
 }
 
 /**
- * ges_uri_clip_asset_new_sync:
+ * ges_uri_clip_asset_request_sync:
  * @uri: The URI of the file for which to create a #GESUriClipAsset
  * @error: (allow-none): An error to be set in case something wrong happens or %NULL
  *
  * Creates a #GESUriClipAsset for @uri syncronously. You should avoid
  * to use it in application, and rather create #GESUriClipAsset asynchronously
  *
- * Returns: A reference to the requested asset or %NULL if an error happend
+ * Returns: (transfer none): A reference to the requested asset or %NULL if an error happend
  */
 GESUriClipAsset *
 ges_uri_clip_asset_request_sync (const gchar * uri, GError ** error)

--- a/tests/check/Makefile.am
+++ b/tests/check/Makefile.am
@@ -40,7 +40,8 @@ check_PROGRAMS = \
 	ges/transition	\
 	ges/overlays\
 	ges/text_properties\
-	ges/project
+	ges/project \
+	ges/render
 
 noinst_LTLIBRARIES=$(testutils_noisnt_libraries)
 noinst_HEADERS=$(testutils_noinst_headers)

--- a/tests/check/ges/render.c
+++ b/tests/check/ges/render.c
@@ -1,0 +1,443 @@
+/* GStreamer Editing Services
+ * Copyright (C) 2013 Mathieu Duponchelle <mduponchelle1@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "test-utils.h"
+#include <ges/ges.h>
+#include <gst/check/gstcheck.h>
+
+/* *INDENT-OFF* */
+static const char * const profile_specs[][3] = {
+  { "application/ogg", "audio/x-vorbis", "video/x-theora" },
+  { "video/webm", "audio/x-vorbis", "video/x-vp8"},
+};
+/* *INDENT-ON* */
+
+typedef enum
+{
+  PROFILE_OGG,
+  PROFILE_MP4,
+} PROFILE_TYPE;
+
+typedef struct _PresetInfos
+{
+  const gchar *muxer_preset_name;
+  const gchar *audio_preset_name;
+  const gchar *video_preset_name;
+
+  gsize expected_size;
+
+} PresetInfos;
+
+static GMainLoop *loop;
+static GESTimelinePipeline *pipeline = NULL;
+
+/* This allow us to run the tests multiple times with different input files */
+static gchar *testfilename1 = NULL;
+static gchar *testfilename2 = NULL;
+
+#define DEFAULT_PROFILE_TYPE PROFILE_MP4
+#define ACCEPTABILITY 0.1 * GST_SECOND
+
+static GstEncodingProfile *
+create_profile (const char *container, const char *container_preset,
+    const char *audio, const char *audio_preset, const char *video,
+    const char *video_preset)
+{
+  GstEncodingContainerProfile *cprof = NULL;
+  GstEncodingProfile *prof = NULL;
+  GstCaps *caps;
+
+  /* If we have both audio and video, we must have container */
+  if (audio && video && !container)
+    return NULL;
+
+  if (container) {
+    caps = gst_caps_from_string (container);
+    cprof = gst_encoding_container_profile_new ("User profile", "User profile",
+        caps, NULL);
+    gst_caps_unref (caps);
+    if (!cprof)
+      return NULL;
+    if (container_preset)
+      gst_encoding_profile_set_preset ((GstEncodingProfile *) cprof,
+          container_preset);
+  }
+
+  if (audio) {
+    caps = gst_caps_from_string (audio);
+    prof = (GstEncodingProfile *) gst_encoding_audio_profile_new (caps, NULL,
+        NULL, 0);
+    if (!prof)
+      goto beach;
+    if (audio_preset)
+      gst_encoding_profile_set_preset (prof, audio_preset);
+    if (cprof)
+      gst_encoding_container_profile_add_profile (cprof, prof);
+    gst_caps_unref (caps);
+  }
+  if (video) {
+    caps = gst_caps_from_string (video);
+    prof = (GstEncodingProfile *) gst_encoding_video_profile_new (caps, NULL,
+        NULL, 0);
+    if (!prof)
+      goto beach;
+    if (video_preset)
+      gst_encoding_profile_set_preset (prof, video_preset);
+    if (cprof)
+      gst_encoding_container_profile_add_profile (cprof, prof);
+    gst_caps_unref (caps);
+  }
+
+  return cprof ? (GstEncodingProfile *) cprof : (GstEncodingProfile *) prof;
+
+beach:
+  if (cprof)
+    gst_encoding_profile_unref (cprof);
+  else
+    gst_encoding_profile_unref (prof);
+  return NULL;
+}
+
+static GstEncodingProfile *
+create_audio_video_profile (PROFILE_TYPE type)
+{
+  return create_profile (profile_specs[type][0], NULL, profile_specs[type][1],
+      NULL, profile_specs[type][2], NULL);
+}
+
+#define ACCEPTABILITY 0.1 * GST_SECOND
+
+/* This is used to specify a dot dumping after the target element started outputting buffers */
+static gchar *target_element = NULL;
+
+static GstPadProbeReturn
+dump_to_dot (GstPad * pad, GstPadProbeInfo * info)
+{
+  GST_DEBUG_BIN_TO_DOT_FILE (GST_BIN (pipeline), GST_DEBUG_GRAPH_SHOW_ALL,
+      "pipelinestate");
+  return (GST_PAD_PROBE_REMOVE);
+}
+
+static gboolean
+my_bus_callback (GstBus * bus, GstMessage * message, gpointer data)
+{
+  gboolean *ret = (gboolean *) data;
+
+  switch (GST_MESSAGE_TYPE (message)) {
+    case GST_MESSAGE_STATE_CHANGED:{
+      GstState old_state, new_state;
+
+      gst_message_parse_state_changed (message, &old_state, &new_state, NULL);
+      /* HACK */
+      if (new_state == GST_STATE_PLAYING
+          && !g_strcmp0 (GST_MESSAGE_SRC_NAME (message), target_element))
+        gst_pad_add_probe (gst_element_get_static_pad (GST_ELEMENT
+                (GST_MESSAGE_SRC (message)), "src"), GST_PAD_PROBE_TYPE_BUFFER,
+            (GstPadProbeCallback) dump_to_dot, NULL, NULL);
+      break;
+    }
+    case GST_MESSAGE_ERROR:{
+      GError *err;
+      gchar *debug;
+
+      gst_message_parse_error (message, &err, &debug);
+      g_print ("Error: %s\n", err->message);
+      g_error_free (err);
+      g_free (debug);
+      g_main_loop_quit (loop);
+      break;
+    }
+    case GST_MESSAGE_EOS:
+      g_print ("EOS\n");
+      *ret = TRUE;
+      g_main_loop_quit (loop);
+      break;
+    default:
+      /* unhandled message */
+      break;
+  }
+  return TRUE;
+}
+
+static gboolean
+test_rendering_timeline_with_profile (GESTimeline * timeline,
+    PROFILE_TYPE profile_type)
+{
+  GstEncodingProfile *profile;
+  GstBus *bus;
+  static gboolean ret;
+  gchar *uri = ges_test_file_uri ("rendered.ogv");
+
+  ret = FALSE;
+
+  profile = create_audio_video_profile (profile_type);
+
+  pipeline = ges_timeline_pipeline_new ();
+
+  ges_timeline_pipeline_set_render_settings (pipeline, uri, profile);
+
+  g_free (uri);
+  gst_object_unref (profile);
+
+  ges_timeline_pipeline_set_mode (pipeline, TIMELINE_MODE_RENDER);
+
+  bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
+  gst_bus_add_watch (bus, my_bus_callback, &ret);
+  gst_object_unref (bus);
+
+  ges_timeline_pipeline_add_timeline (pipeline, timeline);
+
+  gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_PLAYING);
+  gst_element_get_state (GST_ELEMENT (pipeline), NULL, NULL, -1);
+
+  g_main_loop_run (loop);
+
+  gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_NULL);
+  gst_element_get_state (GST_ELEMENT (pipeline), NULL, NULL, -1);
+
+  gst_object_unref (pipeline);
+
+  return ret;
+}
+
+static gboolean
+check_rendered_file_properties (GstClockTime duration)
+{
+  gchar *uri;
+  GESUriClipAsset *asset;
+  GstDiscovererInfo *info;
+  GError *error = NULL;
+  GstClockTime real_duration;
+
+  /* TODO: extend these tests */
+
+  uri = ges_test_file_uri ("rendered.ogv");
+  asset = ges_uri_clip_asset_request_sync (uri, &error);
+  g_free (uri);
+
+  info = ges_uri_clip_asset_get_info (GES_URI_CLIP_ASSET (asset));
+  gst_object_unref (asset);
+
+  if (!(GST_IS_DISCOVERER_INFO (info)))
+    return FALSE;
+
+  /* Let's not be too nazi */
+
+  real_duration = gst_discoverer_info_get_duration (info);
+
+  if ((duration < real_duration - ACCEPTABILITY)
+      || (duration > real_duration + ACCEPTABILITY))
+    return FALSE;
+
+  gst_object_unref (info);
+
+  return TRUE;
+}
+
+/* Test adding an effect [E] marks the effect (FIXME : disabled because "couldn't get a pad from encodebin" */
+GST_START_TEST (test_effect_rendering)
+{
+  GESTimeline *timeline;
+  GESLayer *layer;
+  GError *error = NULL;
+  GESUriClipAsset *asset1;
+  GESEffect *effect;
+  GESClip *clip;
+  gchar *uri = ges_test_file_uri (testfilename1);
+
+  asset1 = ges_uri_clip_asset_request_sync (uri, &error);
+  g_free (uri);
+
+  layer = ges_layer_new ();
+  timeline = ges_timeline_new_audio_video ();
+  fail_unless (ges_timeline_add_layer (timeline, layer));
+
+  clip =
+      ges_layer_add_asset (layer, GES_ASSET (asset1), 0 * GST_SECOND,
+      0 * GST_SECOND, 1 * GST_SECOND, GES_TRACK_TYPE_UNKNOWN);
+  gst_object_unref (asset1);
+
+  effect = ges_effect_new ("agingtv");
+  ges_container_add (GES_CONTAINER (clip), GES_TIMELINE_ELEMENT (effect));
+
+    /**
+   * Our timeline
+   *          [   E    ]
+   * inpoints 0--------0 
+   *          |  clip  | 
+   * time     0--------1
+   */
+
+  fail_unless (test_rendering_timeline_with_profile (timeline, PROFILE_OGG));
+  fail_unless (check_rendered_file_properties (1 * GST_SECOND));
+}
+
+GST_END_TEST;
+
+GST_START_TEST (test_transition)
+{
+  GESTimeline *timeline;
+  GESLayer *layer;
+  GError *error = NULL;
+  GESUriClipAsset *asset1, *asset2;
+  GESClip *clip;
+  gchar *uri1 = ges_test_file_uri (testfilename1);
+  gchar *uri2 = ges_test_file_uri (testfilename2);
+
+  timeline = ges_timeline_new_audio_video ();
+  layer = ges_layer_new ();
+  fail_unless (ges_timeline_add_layer (timeline, layer));
+
+  g_object_set (layer, "auto-transition", TRUE, NULL);
+
+  asset1 = ges_uri_clip_asset_request_sync (uri1, &error);
+  asset2 = ges_uri_clip_asset_request_sync (uri2, &error);
+
+  g_free (uri1);
+  g_free (uri2);
+
+  clip =
+      ges_layer_add_asset (layer, GES_ASSET (asset1), 0 * GST_SECOND,
+      0 * GST_SECOND, 2 * GST_SECOND, GES_TRACK_TYPE_UNKNOWN);
+  gst_object_unref (asset1);
+
+  clip =
+      ges_layer_add_asset (layer, GES_ASSET (asset2), 1 * GST_SECOND,
+      0 * GST_SECOND, 2 * GST_SECOND, GES_TRACK_TYPE_UNKNOWN);
+  gst_object_unref (asset2);
+
+  ges_timeline_element_set_start (GES_TIMELINE_ELEMENT (clip), 1 * GST_SECOND);
+
+    /**
+   * Our timeline
+   *                    [T]
+   * inpoints 0--------0 0--------0
+   *          |  clip  | |  clip2 |
+   * time     0------- 2 1--------3
+   */
+
+  fail_unless (test_rendering_timeline_with_profile (timeline, PROFILE_OGG));
+
+  fail_unless (check_rendered_file_properties (3 * GST_SECOND));
+}
+
+GST_END_TEST;
+
+GST_START_TEST (test_basic_render)
+{
+  GESTimeline *timeline;
+  GESLayer *layer;
+  GESUriClipAsset *asset1;
+  GError *error = NULL;
+  gchar *uri = ges_test_file_uri (testfilename1);
+
+  asset1 = ges_uri_clip_asset_request_sync (uri, &error);
+  g_free (uri);
+
+  layer = ges_layer_new ();
+  timeline = ges_timeline_new_audio_video ();
+  fail_unless (ges_timeline_add_layer (timeline, layer));
+
+  ges_layer_add_asset (layer, GES_ASSET (asset1), 0 * GST_SECOND,
+      0 * GST_SECOND, 1 * GST_SECOND, GES_TRACK_TYPE_UNKNOWN);
+  gst_object_unref (asset1);
+  /* Test most simple case */
+
+    /**
+   * Our timeline
+   *
+   * inpoints 0--------0
+   *          |  clip  |
+   * time     0--------1
+   */
+
+  fail_unless (test_rendering_timeline_with_profile (timeline, PROFILE_OGG));
+
+  fail_unless (check_rendered_file_properties (1 * GST_SECOND));
+}
+
+GST_END_TEST;
+
+static Suite *
+ges_suite (void)
+{
+  Suite *s = suite_create ("ges-render");
+  TCase *tc_chain = tcase_create ("render");
+
+  suite_add_tcase (s, tc_chain);
+
+  tcase_add_test (tc_chain, test_basic_render);
+  tcase_add_test (tc_chain, test_effect_rendering);
+  tcase_add_test (tc_chain, test_transition);
+
+  /* TODO : next test case : complex timeline created from project. */
+  /* TODO : deep checking of rendered clips */
+  /* TODO : might be interesting to try all profiles, and maintain a list of currently working profiles ? */
+
+  return s;
+}
+
+static void
+generate_all_files (void)
+{
+  ges_generate_test_file_audio_video ("ges/test1.webm", "vorbisenc", "vp8enc",
+      "webmmux", "18", "11");
+  ges_generate_test_file_audio_video ("ges/test2.webm", "vorbisenc", "vp8enc",
+      "webmmux", "0", "0");
+  ges_generate_test_file_audio_video ("ges/test1.ogv", "vorbisenc", "theoraenc",
+      "oggmux", "18", "11");
+  ges_generate_test_file_audio_video ("ges/test2.ogv", "vorbisenc", "theoraenc",
+      "oggmux", "0", "0");
+}
+
+int
+main (int argc, char **argv)
+{
+  int nf;
+
+  Suite *s = ges_suite ();
+  SRunner *sr = srunner_create (s);
+
+  gst_check_init (&argc, &argv);
+
+  loop = g_main_loop_new (NULL, FALSE);
+
+  ges_init ();
+
+  generate_all_files ();
+
+  g_print ("Running suite with webm vorbis/vp8\n");
+  testfilename1 = g_strdup ("test1.webm");
+  testfilename2 = g_strdup ("test2.webm");
+  srunner_run_all (sr, CK_NORMAL);
+  g_free (testfilename1);
+  g_free (testfilename2);
+
+  g_print ("Running suite with ogg vorbis/theora\n");
+  testfilename1 = g_strdup ("test1.ogv");
+  testfilename2 = g_strdup ("test2.ogv");
+  srunner_run_all (sr, CK_NORMAL);
+  g_free (testfilename1);
+  g_free (testfilename2);
+
+  nf = srunner_ntests_failed (sr);
+  srunner_free (sr);
+
+  return nf;
+}

--- a/tests/check/ges/test-utils.c
+++ b/tests/check/ges/test-utils.c
@@ -111,6 +111,8 @@ ges_generate_test_file_audio_video (const gchar * filedest,
 
   pipeline = gst_parse_launch (pipeline_str, &error);
 
+  g_free (pipeline_str);
+
   bus = gst_element_get_bus (GST_ELEMENT (pipeline));
   gst_bus_add_signal_watch (bus);
 

--- a/tests/check/ges/test-utils.c
+++ b/tests/check/ges/test-utils.c
@@ -84,3 +84,45 @@ ges_test_file_uri (const gchar * filename)
 
   return uri;
 }
+
+void
+ges_generate_test_file_audio_video (const gchar * filedest,
+    const gchar * audio_enc,
+    const gchar * video_enc,
+    const gchar * mux, const gchar * video_pattern, const gchar * audio_wave)
+{
+  GError *error = NULL;
+  GstElement *pipeline;
+  GstBus *bus;
+  GstMessage *message;
+  gchar *pipeline_str;
+  gboolean done = FALSE;
+
+  if (g_file_test (filedest, G_FILE_TEST_EXISTS)) {
+    GST_INFO ("The file %s already existed.", filedest);
+    return;
+  }
+
+  pipeline_str = g_strdup_printf ("audiotestsrc num-buffers=430 wave=%s "
+      "! %s ! %s name=m ! filesink location= %s/%s "
+      "videotestsrc pattern=%s num-buffers=300 ! %s ! m.",
+      audio_wave, audio_enc, mux, g_get_current_dir (),
+      filedest, video_pattern, video_enc);
+
+  pipeline = gst_parse_launch (pipeline_str, &error);
+
+  bus = gst_element_get_bus (GST_ELEMENT (pipeline));
+  gst_bus_add_signal_watch (bus);
+
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+
+  while (!done) {
+    message = gst_bus_poll (bus, GST_MESSAGE_ANY, GST_CLOCK_TIME_NONE);
+    if (GST_MESSAGE_TYPE (message) & GST_MESSAGE_EOS)
+      done = TRUE;
+    else if (GST_MESSAGE_TYPE (message) & GST_MESSAGE_ERROR) {
+      done = TRUE;
+      g_print ("Error");
+    }
+  }
+}

--- a/tests/check/ges/test-utils.h
+++ b/tests/check/ges/test-utils.h
@@ -24,10 +24,15 @@
 
 #include <ges/ges.h>
 
-gchar * ges_test_get_audio_only_uri (void);
-gchar * ges_test_get_audio_video_uri (void);
-gchar * ges_test_get_image_uri (void);
-gchar * ges_test_file_uri (const gchar *filename);
+gchar *ges_test_get_audio_only_uri (void);
+gchar *ges_test_get_audio_video_uri (void);
+gchar *ges_test_get_image_uri (void);
+gchar *ges_test_file_uri (const gchar * filename);
+void
+ges_generate_test_file_audio_video (const gchar * filedest,
+    const gchar * audio_enc,
+    const gchar * video_enc,
+    const gchar * mux, const gchar * video_pattern, const gchar * audio_wave);
 
 #define gnl_object_check(gnlobj, start, duration, mstart, mduration, priority, active) { \
   guint64 pstart, pdur, pmstart, pmdur, pprio, pact;			\


### PR DESCRIPTION
# review:
- [x] Show you how to state it is done :) (just edit that to add the 'x')
- [x] remove trailing witespaces
- [x] s/ACCEPTABILITY/duration_tolerance/ ?
- [ ] We do not properly see transitions value on schemes in test_transition

Media files generation:
- [x] Check that everything whent ok
- [ ] Make sure we have elements before generating/testing the format
- [ ] You should use gst_check_run_suite instead of srunner_run_all

$make distcheck

```
Unexpected critical/warning: ges_layer_add_asset: assertion `GES_IS_ASSET (asset)' failed
Unexpected critical/warning: ges_layer_add_asset: assertion `GES_IS_ASSET (asset)' failed
Unexpected critical/warning: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Resource not found.
0%: Checks: 6, Failures: 6, Errors: 0
gstcheck.c:75:F:render:test_basic_render:0: Unexpected critical/warning: ges_layer_add_asset: assertion `GES_IS_ASSET (asset)' failed
gstcheck.c:75:F:render:test_effect_rendering:0: Unexpected critical/warning: ges_layer_add_asset: assertion `GES_IS_ASSET (asset)' failed
gstcheck.c:75:F:render:test_transition:0: Unexpected critical/warning: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Resource not found.
gstcheck.c:75:F:render:test_basic_render:0: Unexpected critical/warning: ges_layer_add_asset: assertion   `GES_IS_ASSET (asset)' failed
gstcheck.c:75:F:render:test_effect_rendering:0: Unexpected critical/warning: ges_layer_add_asset: assertion `GES_IS_ASSET (asset)' failed
gstcheck.c:75:F:render:test_transition:0: Unexpected critical/warning: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Resource not found.
FAIL: ges/render
```
- [ ] Make distcheck

This is details and it is very good stuff in overall :)
